### PR TITLE
Added transcript url

### DIFF
--- a/xmodule/video_block/video_block.py
+++ b/xmodule/video_block/video_block.py
@@ -875,6 +875,7 @@ class VideoBlock(
         video_url = metadata_fields['html5_sources']
         video_id = metadata_fields['edx_video_id']
         youtube_id_1_0 = metadata_fields['youtube_id_1_0']
+        transcript_url = metadata_fields['transcript_url']
 
         def get_youtube_link(video_id):
             """
@@ -931,7 +932,8 @@ class VideoBlock(
         metadata = {
             'display_name': display_name,
             'video_url': video_url,
-            'edx_video_id': video_id
+            'edx_video_id': video_id,
+            'transcript_url': transcript_url
         }
 
         _context.update({'transcripts_basic_tab_metadata': metadata})

--- a/xmodule/video_block/video_handlers.py
+++ b/xmodule/video_block/video_handlers.py
@@ -12,6 +12,7 @@ import math
 
 from django.core.files.base import ContentFile
 from django.utils.timezone import now
+import requests
 from edxval.api import create_external_video, create_or_update_video_transcript, delete_video_transcript
 from opaque_keys.edx.locator import CourseLocator
 from webob import Response
@@ -309,6 +310,16 @@ class VideoStudentViewHandlers:
                     Returns list of languages, for which transcript files exist.
                     For 'en' check if SJSON exists. For non-`en` check if SRT file exists.
         """
+        if self.transcript_url:
+            try:
+                return Response(Transcript.convert(
+                        content=requests.get(self.transcript_url).text,
+                        input_format=Transcript.SRT,
+                        output_format=Transcript.SJSON
+                    ))
+
+            except Exception as err:
+                return Response(status=404)
         is_bumper = request.GET.get('is_bumper', False)
         transcripts = self.get_transcripts_info(is_bumper)
 

--- a/xmodule/video_block/video_xfields.py
+++ b/xmodule/video_block/video_xfields.py
@@ -120,6 +120,13 @@ class VideoFields:
         scope=Scope.settings,
         default=""
     )
+    transcript_url = String(
+        help=_("The default transcript for the video, from the Default Timed Transcript field on the Basic tab. "
+               "This transcript should be in English. You don't have to change this setting."),
+        display_name=_("Transcript URL"),
+        scope=Scope.settings,
+        default=""
+    )
     show_captions = Boolean(
         help=_("Specify whether the transcripts appear with the video by default."),
         display_name=_("Show Transcript"),


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
